### PR TITLE
docs: simplify README installation with one-shot setup scripts

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,10 +1,10 @@
-# whether to use the project's gitignore file to ignore files
-# Added on 2025-04-07
+
+# whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
-# list of additional paths to ignore
-# same syntax as gitignore, so you can use * and **
-# Was previously called `ignored_dirs`, please update your config if you are using that.
-# Added (renamed)on 2025-04-07
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -12,8 +12,9 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
 # Below is the complete list of tools for convenience.
 # To make sure you have the latest list of tools, and to view their descriptions,
 # execute `uv run scripts/print_tool_overview.py`.
@@ -28,7 +29,7 @@ read_only: false
 #  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
 #  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
 #  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file or directory.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
 #  * `initial_instructions`: Gets the initial instructions for the current project.
 #     Should only be used in settings where the system prompt cannot be set,
 #     e.g. in clients you have no control over, like Claude Desktop.
@@ -75,7 +76,8 @@ base_modes:
 # This setting can, in turn, be overridden by CLI parameters (--mode).
 default_modes:
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
@@ -93,10 +95,10 @@ encoding: utf-8
 #   fortran             fsharp              go                  groovy              haskell
 #   java                julia               kotlin              lua                 markdown
 #   matlab              nix                 pascal              perl                php
-#   powershell          python              python_jedi         r                   rego
-#   ruby                ruby_solargraph     rust                scala               swift
-#   terraform           toml                typescript          typescript_vts      vue
-#   yaml                zig
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
@@ -134,3 +136,17 @@ line_ending:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 🎵 **A simple, interactive command-line tool for YouTube Music**
 
-> Testing Azure Pipelines with Claude code review integration
-
 Stream music directly from YouTube Music in your terminal with intuitive controls, playlist management, and smart filtering.
 
 ![YTM CLI Player](image.png)

--- a/README.md
+++ b/README.md
@@ -35,44 +35,43 @@ Stream music directly from YouTube Music in your terminal with intuitive control
    cd ytm
    ```
 
-2. **Set up virtual environment**
+2. **Run the one-shot setup script**
 
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
-   ```
-
-3. **Install dependencies**
-
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-4. **Quick alias setup (Optional but recommended)**
-
-   For easier access with just `ytm` command:
+   This creates the virtual environment, installs dependencies, and configures the `ytm` command for you.
 
    **Linux/macOS:**
 
    ```bash
-   ./setup_alias.sh
+   ./setup.sh
    source ~/.zshrc  # or ~/.bashrc for bash
    ```
 
    **Windows PowerShell:**
 
    ```powershell
-   .\setup_alias.ps1
+   .\setup.ps1
    . $PROFILE
    ```
 
    **Windows Command Prompt:**
 
    ```cmd
-   setup_alias.bat
+   setup.bat
    ```
 
-   After setup, use `ytm` from anywhere instead of `python -m ytm_cli`
+   After setup, use `ytm` from anywhere instead of `python -m ytm_cli`.
+
+   <details>
+   <summary>Manual install (if you prefer)</summary>
+
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # Windows: venv\Scripts\activate
+   pip install -r requirements.txt
+   ./setup_alias.sh          # or setup_alias.ps1 / setup_alias.bat
+   ```
+
+   </details>
 
 ### Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -209,4 +209,3 @@ This project is open source. Please check the license file for details.
 ---
 
 **Enjoy your music! 🎵**
-# Test PR trigger


### PR DESCRIPTION
Streamlines the installation section in README.md to promote the new one-shot setup scripts (`setup.sh`, `setup.ps1`, `setup.bat`) as the primary install method, with manual steps collapsed in a `<details>` block.